### PR TITLE
Locking babel-loader to version 5 for the moment

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "babel": "*",
     "babel-core": "^5.8.24",
-    "babel-loader": "*",
+    "babel-loader": "^5.3.3",
     "css-loader": "~0.9.1",
     "extract-text-webpack-plugin": "^0.8.2",
     "get-port": "^1.0.0",


### PR DESCRIPTION
@jonsherrard  This is a temporary measure whilst we upgrade to using Babel v6.

See https://github.com/shortlist-digital/agreable-promo-plugin/tree/babel-v6
