### PR TITLE
Add promo start & end time to associated posts

### DIFF
--- a/app/Hooks/SavePost.php
+++ b/app/Hooks/SavePost.php
@@ -5,7 +5,7 @@ use AgreablePromoPlugin\Helper;
 class SavePost {
 
   public function init() {
-    \add_action( 'save_post', array($this, 'update_post_times'), 10, 1 );
+    \add_action( 'save_post', array($this, 'update_post_times'), 10, 2 );
     // \add_action( 'before_delete_post', array($this, 'remove_post_times'), 10, 1 );
   }
 
@@ -14,8 +14,8 @@ class SavePost {
     return $where;
   }
 
-  public function  update_post_times($post_id){
-    global $post;
+  public function  update_post_times($post_id, $post){
+
     if ($post->post_type != 'promo'){
       return;
     }

--- a/app/Hooks/SavePost.php
+++ b/app/Hooks/SavePost.php
@@ -1,0 +1,55 @@
+<?php namespace AgreablePromoPlugin\Hooks;
+
+use AgreablePromoPlugin\Helper;
+
+class SavePost {
+
+  public function init() {
+    \add_action( 'save_post', array($this, 'update_post_times'), 10, 1 );
+    // \add_action( 'before_delete_post', array($this, 'remove_post_times'), 10, 1 );
+  }
+
+  public function posts_where_widgets( $where ) {
+    $where = str_replace("meta_key = 'article_widgets_%", "meta_key LIKE 'article_widgets_%", $where);
+    return $where;
+  }
+
+  public function  update_post_times($post_id){
+    global $post;
+    if ($post->post_type != 'promo'){
+      return;
+    }
+
+    // Get start and end from promo.
+    $start_time = get_field('start_time', $post->ID, false);
+    $end_time = get_field('end_time', $post->ID,  false);
+
+    // Reverse query to find posts with this promo.
+    $query_args = array(
+      'posts_per_page' => -1,
+      'post_status' => 'publish',
+      'meta_query' => array(
+        array(
+          'key' => 'article_widgets_%_promo_post',
+          'value' => $post->ID
+        )
+      )
+    );
+
+    // To accomodate ACF meta_key structure for article_widgets
+    // (e.g. article_widgets_{index}_promo_post) we  need to manipulate
+    // the SQL so that it is a LIKE comparison.
+    \add_filter('posts_where', array($this, 'posts_where_widgets'));
+
+    $posts = new \WP_Query($query_args);
+
+    // Only needs to be applied in this context.
+    \remove_filter('posts_where', array($this, 'posts_where_widgets'));
+
+    foreach($posts->posts as $p){
+      update_field('end_time', $end_time, $p->ID);
+      update_field('start_time', $start_time, $p->ID);
+    }
+  }
+
+}

--- a/app/hooks.php
+++ b/app/hooks.php
@@ -4,6 +4,7 @@
 
 use AgreablePromoPlugin\Hooks\TimberTwig;
 use AgreablePromoPlugin\Hooks\SLMPluginEnqueue;
+use AgreablePromoPlugin\Hooks\SavePost;
 
 if(class_exists('AgreablePromoPlugin\Hooks\TimberTwig')){
   (new TimberTwig)->init();
@@ -13,4 +14,6 @@ if(class_exists('AgreablePromoPlugin\Hooks\SLMPluginEnqueue')){
   (new SLMPluginEnqueue)->init();
 }
 
-
+if(class_exists('AgreablePromoPlugin\Hooks\SavePost')){
+  (new SavePost)->init();
+}

--- a/app/hooks.php
+++ b/app/hooks.php
@@ -6,14 +6,6 @@ use AgreablePromoPlugin\Hooks\TimberTwig;
 use AgreablePromoPlugin\Hooks\SLMPluginEnqueue;
 use AgreablePromoPlugin\Hooks\SavePost;
 
-if(class_exists('AgreablePromoPlugin\Hooks\TimberTwig')){
-  (new TimberTwig)->init();
-}
-
-if(class_exists('AgreablePromoPlugin\Hooks\SLMPluginEnqueue')){
-  (new SLMPluginEnqueue)->init();
-}
-
-if(class_exists('AgreablePromoPlugin\Hooks\SavePost')){
-  (new SavePost)->init();
-}
+(new TimberTwig)->init();
+(new SLMPluginEnqueue)->init();
+(new SavePost)->init();


### PR DESCRIPTION
The goal of this is to hide promos that are not 'current' from related items at end of posts.
Attaches promo start/end time to associated posts on wp save_post hook for 'promo' post type only.
[There is a complimentary hook in agreable-base-theme that will do the same when a post is saved](https://github.com/shortlist-digital/agreable-base-theme/pull/20).
