### PR TITLE
Updated timings to ISO format

### DIFF
--- a/resources/views/widgets/promo_plugin/template.twig
+++ b/resources/views/widgets/promo_plugin/template.twig
@@ -28,8 +28,8 @@
       "text" : {{promo.terms_and_conditions|escape|json_encode}}
     },
     "timings": {
-      "start": "{{promo.start_time}}",
-      "end": "{{promo.end_time}}"
+      "start": "{{promo.start_time|date('c')}}",
+      "end": "{{promo.end_time|date('c')}}"
     }
     {% if 'competition' in promo.get_field('data_to_capture') %}
     ,"competition": {


### PR DESCRIPTION
Added `|date('c')` to parse the dates correctly for Safari.
